### PR TITLE
feat: update to nodejs18.x AWS Lambda runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "handler.js",
   "engines": {
-    "node": ">=16",
-    "npm": ">=8"
+    "node": ">=18",
+    "npm": ">=9"
   },
   "scripts": {
     "sls": "serverless",

--- a/serverless.yml
+++ b/serverless.yml
@@ -2,7 +2,7 @@ service: serverless-indexer
 
 provider:
   name: aws
-  runtime: nodejs14.x
+  runtime: nodejs18.x
   stage: ${opt:stage, 'dev'}
   profile: ${file(./.env.yml):AWS_PROFILE}
   region: us-east-2


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
This PR bumps the runtime from Node.js v14.x to v18.x, which is the latest supported runtime for AWS Lambda functions ([source](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)).

While the Node.js v20.x will become the active LTS version starting on October, 24, 2023, the AWS team doesn't have a timeline for releasing a Lambda runtime at this time ([source](https://github.com/aws/aws-lambda-base-images/issues/91).

Once Node v20 is released as a Lambda runtime, we should be able to bump up the runtime version for the indexer again.

Note: After being merged, this will need to be deployed to production with `npm run deploy`.